### PR TITLE
refactor(build): centralize native sharp reinstall into shared script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "predev": "npm run ensure-platform",
     "pretest": "npm run ensure-platform",
     "ensure-platform": "node scripts/ensure-platform.js",
-    "prerelease:mac": "npm uninstall sharp && npm install sharp --os=darwin --cpu=x64",
+    "prerelease:mac": "node scripts/reinstall-native-sharp.js darwin x64",
     "release:mac": "node macos-release.js",
-    "prerelease:win": "npm uninstall sharp && npm install sharp --os=win32 --cpu=x64",
+    "prerelease:win": "node scripts/reinstall-native-sharp.js win32 x64",
     "release:win": "GH_TOKEN=$(gh auth token) electron-builder --win --publish always",
     "clean": "rm -rf dist/*"
   },

--- a/scripts/reinstall-native-sharp.js
+++ b/scripts/reinstall-native-sharp.js
@@ -1,0 +1,18 @@
+const { execSync } = require("child_process");
+const { dependencies } = require("../package.json");
+
+const [platform, arch] = process.argv.slice(2);
+
+if (!platform || !arch) {
+  console.error("Usage: node reinstall-native-sharp.js <platform> <arch>");
+  process.exit(1);
+}
+
+const version = dependencies.sharp.replace(/^[\^~]/, "");
+
+console.log(`Reinstalling sharp@${version} for ${platform}/${arch} (node_modules only)...`);
+execSync("npm uninstall sharp --no-save", { stdio: "inherit" });
+execSync(`npm install sharp@${version} --no-save --os=${platform} --cpu=${arch}`, {
+  stdio: "inherit",
+});
+console.log("Done.");


### PR DESCRIPTION
Both release scripts inlined the same uninstall/install sequence, which skipped --no-save and could pollute package.json. Extract the logic into scripts/reinstall-native-sharp.js, reading the sharp version from package.json and reinstalling for the given platform/arch.